### PR TITLE
Exceptions in GetStreamFromPath(string) specify if assembly was found or not

### DIFF
--- a/vke/src/Utils.cs
+++ b/vke/src/Utils.cs
@@ -55,8 +55,7 @@ namespace Vulkan {
 
 				if (assembly != null)
 					new Exception("Embedded resource not found in assembly: " + path);
-
-				throw new Exception ("Resource not found: " + path);
+				throw new Exception ("Assembly not found: " + path);
 			}
 			if (!File.Exists (path))
 				throw new FileNotFoundException ("File not found: ", path);

--- a/vke/src/Utils.cs
+++ b/vke/src/Utils.cs
@@ -52,6 +52,10 @@ namespace Vulkan {
 						.FirstOrDefault (aa => aa.GetName ().Name == $"{assemblyNames[0]}.{assemblyNames[1]}");
 				if (assembly != null && tryFindResource (assembly, resId, out stream))
 					return stream;
+
+				if (assembly != null)
+					new Exception("Embedded resource not found in assembly: " + path);
+
 				throw new Exception ("Resource not found: " + path);
 			}
 			if (!File.Exists (path))


### PR DESCRIPTION
Basically just states if the assembly was able to be found or not.