### PR TITLE
Make MSBuild a development dependency in SpirVTasks.

### DIFF
--- a/SpirVTasks/SpirVTasks.csproj
+++ b/SpirVTasks/SpirVTasks.csproj
@@ -28,7 +28,7 @@
 		<RestoreIgnoreFailedSource>true</RestoreIgnoreFailedSource>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.0.461" />
+		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.0.461" PrivateAssets="all" />
 	</ItemGroup>
 	<ItemGroup>
 		<Content Include="SpirVTasks.targets">


### PR DESCRIPTION
MSBuild doesn't need to be referenced by projects that use SpirVTasks.